### PR TITLE
Add a "Who We Are" page.

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -1,14 +1,41 @@
 - name: Madeleine Bonsma
-  degree: PhD, Physics
+  degree: MSc, Physics
   github: mbonsma
+  interests:
+    - Python
 
 - name: Deepak Chandan
   degree: PhD, Physics
   github: dchandan
 
-- name: Melanie Cooke
+- name: Melanie A Cooke
   degree: PhD, Physics
   github: melaniecooke
+  interests:
+    - Python
+
+- name: Andre R Erler
+  degree: PhD, Physics
+  github: aerler
+
+- name: Chris Granstrom
+  degree: PhD, Physics
+  github: cgranstrom
+  interests:
+    - C/C++
+    - Python
+
+- name: Ciaran J Hickey
+  github: hickeyc
+  interests:
+    - C++
+    - Fortran90
+
+- name: Lanna S Jin
+  degree: PhD, Ecology &amp; Evolutionary Biology
+  github: lannajin
+  interests:
+    - R
 
 - name: Luke W Johnston
   degree: PhD, Nutritional Sciences
@@ -19,6 +46,13 @@
 
 - name: Aaron Liblong
   github: aliblong
+
+- name: Chuangxin Lin
+  degree: PhD, Physics
+  github: Chancylin
+  interests:
+    - Fortran
+    - Python
 
 - name: Junjiang Lin
   github: junjianglin
@@ -38,6 +72,12 @@
 - name: Matt Stata
   github: MattStata
 
+- name: Stefanie D Sultmanis
+  github: stefsult
+  interests:
+    - Python
+    - R
+
 - name: Alex Tavasoli
   github: atavasoli
 
@@ -45,5 +85,7 @@
   degree: MSc, Computer Science
   github: ekzhu
 
-- name: Charles Zhu
+- name: Charles Chenchong Zhu
   github: cczhu
+  interests:
+    - Python

--- a/_data/members.yml
+++ b/_data/members.yml
@@ -1,0 +1,49 @@
+- name: Madeleine Bonsma
+  degree: PhD, Physics
+  github: mbonsma
+
+- name: Deepak Chandan
+  degree: PhD, Physics
+  github: dchandan
+
+- name: Melanie Cooke
+  degree: PhD, Physics
+  github: melaniecooke
+
+- name: Luke W Johnston
+  degree: PhD, Nutritional Sciences
+  github: lwjohnst86
+  interests:
+    - R
+    - SAS
+
+- name: Aaron Liblong
+  github: aliblong
+
+- name: Junjiang Lin
+  github: junjianglin
+
+- name: Abigail Cabunoc Mayes
+  degree: Mozilla Science Lab
+  github: acabunoc
+
+- name: Elliott Sales de Andrade
+  degree: PhD, Physics
+  github: QuLogic
+  interests:
+    - Fortran
+    - Python
+    - Visualization
+
+- name: Matt Stata
+  github: MattStata
+
+- name: Alex Tavasoli
+  github: atavasoli
+
+- name: Eric Zhu
+  degree: MSc, Computer Science
+  github: ekzhu
+
+- name: Charles Zhu
+  github: cczhu

--- a/_includes/css/custom.css
+++ b/_includes/css/custom.css
@@ -1,0 +1,6 @@
+.team-member img.img-responsive {
+ max-width: 110px;
+}
+.team-member i.fa {
+ font-size: 110px;
+}

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -11,6 +11,15 @@
             </div>
             <div class="row">
                 {% for member in site.data.members %}
+                {% assign loopindex = forloop.index0 | modulo: 4 %}
+                {% if loopindex == 0 %}
+                {% if forloop.first == false %}
+            </div>
+                {% if forloop.last == false %}
+            <div class="row">
+                {% endif %}
+                {% endif %}
+                {% endif %}
                 <div class="col-sm-3">
                     <div class="team-member">
                         {% if member.github %}

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -3,31 +3,35 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">
-                    <h2 class="section-heading">Our Amazing Team</h2>
-                    <h3 class="section-subheading text-muted">Lorem ipsum dolor sit amet consectetur.</h3>
+                    <h2 class="section-heading">Who We Are</h2>
+                    <h3 class="section-subheading text-muted">
+                        We are a diverse group hailing from multiple departments across the University and beyond.
+                    </h3>
                 </div>
             </div>
             <div class="row">
-                {% for member in site.people %}
-                <div class="col-sm-4">
+                {% for member in site.data.members %}
+                <div class="col-sm-3">
                     <div class="team-member">
-                        <img src="img/team/{{ member.pic }}.jpg" class="img-responsive img-circle" alt="">
+                        {% if member.github %}
+                        <img src="https://avatars.githubusercontent.com/{{ member.github }}?s=96" class="img-responsive img-circle" alt="">
+                        <h4><a href="https://github.com/{{ member.github }}">{{ member.name }}</a></h4>
+                        {% else %}
+                        <i class="fa fa-user"></i>
                         <h4>{{ member.name }}</h4>
-                        <p class="text-muted">{{ member.position }}</p>
-                        <ul class="list-inline social-buttons">
-                            {% for network in member.social %}
-                            <li><a href="{{ network.url }}"><i class="fa fa-{{ network.title }}"></i></a>
+                        {% endif %}
+                        <p class="text-muted"><i>{{ member.degree }}</i></p>
+                        {% if member.interests %}
+                        Interests:
+                        <ul class="list-inline text-muted">
+                            {% for interest in member.interests %}
+                            <li class="fa fa-angle-right">&nbsp;{{ interest }}</li>
                             {% endfor %}
-
                         </ul>
+                        {% endif %}
                     </div>
                 </div>
                 {% endfor %}
-            </div>
-            <div class="row">
-                <div class="col-lg-8 col-lg-offset-2 text-center">
-                    <p class="large text-muted">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aut eaque, laboriosam veritatis, quos non quis ad perspiciatis, totam corporis ea, alias ut unde.</p>
-                </div>
             </div>
         </div>
     </section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,6 +10,7 @@
     {% include services.html %}
     {% include portfolio_grid.html %}
     {% include contact.html %}
+    {% include team.html %}
     {% include footer.html %}
     {% include js.html %}
 

--- a/_layouts/style.css
+++ b/_layouts/style.css
@@ -1,2 +1,3 @@
 {% include css/bootstrap.min.css %}
 {% include css/agency.css %}
+{% include css/custom.css %}


### PR DESCRIPTION
I picked out a few people from the Watchers who have some information in their profile. You can see how it looks [here](https://qulogic.github.io/studyGroup/#team). A couple of points:
- It's sorted alphabetically by last name (easiest way to get @mbonsma first ;)
- I'm not sure what to call the byline key. It's currently `degree`, but e.g., @acabunoc doesn't exactly fall in that category.
- Avatars come from GitHub, so set a profile picture if you want your picture there.
- Names currently link to GitHub profile (or nowhere), but maybe that should be flexible (not hard to fix).
- @lwjohnst86 Filling in people's information seems like a good second step to do after getting through the git tutorial (but I still think they should work on a sandbox for tonight.)
