### PR TITLE
Group Constitution

### DIFF
--- a/Group_Constitution
+++ b/Group_Constitution
@@ -1,0 +1,127 @@
+Constitution of “Mozilla Science Study Group- University of Toronto”
+
+1.	Name
+
+The official name of this recognized campus group is “     ”
+
+The acronym or abbreviation of this group is:      
+
+2.	Purpose and Objectives
+
+The purpose, objectives, mission and/or mandate of organization is outlined here:
+     
+
+3.	Membership
+
+Membership to the group is open to all the University of Toronto members (students, staff, faculty and alumni). 
+
+U of T members are permitted to run, nominate, and vote in elections and constitutional amendments. The group is open to non-U of T members. However, these members do not hold the aforementioned rights. Members must register with a designated executive by submitting their full name and a valid email address.
+
+The membership fee will be $      per year.
+
+Any member of the club may apply for a refund within one (1) month of becoming a member. No refunds are permitted 30 days after the election periods.
+
+For recognition by the University of Toronto Students’ Union (UTSU), the group must maintain a minimum of 30 members, a total of 51% of membership are UTSU members. The group must also maintain recognition from the Office of Student Life. These requirements are subject to change and should be checked with UTSU annually to ensure qualifications are met. 
+
+4.	Executive List and Duties
+
+The executive committee shall be comprised of three (3) elected officers. These include a President, Secretary, and Treasurer.
+
+The President shall:
+•	Oversee the operations, management and success of the group
+•	Be the spokesperson for the group
+•	Hold signing officer authority along with the Treasurer for financial purposes
+•	Preside over board meetings as well as general meetings
+•	Ensure transition of office to the future Executives
+Additional responsibilities may include: 
+     
+
+
+The Vice-President shall:
+•	Assume duties of the President in his/her absence
+•	Oversee the various committees
+•	Ensure that all the activities of the club meet regulations and policies of the University of Toronto
+•	Coordinate organizational recruitment efforts
+Additional responsibilities may include: 
+     
+
+
+The Secretary shall: 
+•	Make a list of all registered members 
+•	Maintain the web sites and member contact list
+•	Record notes and motions for meetings
+•	Notify all members of meetings
+•	Handle official correspondence of the organization
+Additional responsibilities may include: 
+     
+
+
+
+The Treasurer shall:
+•	Record all financial transactions of the group
+•	Hold signing officer authority along with the President for financial purposes
+•	Maintain a budget of income and expenses along with receipts
+•	Advise members on financial position of the group
+•	Prepare an annual budget for the group as well as budgets for specific events
+Additional responsibilities may include: 
+     
+
+
+
+The group may appoint Directors or Coordinators for various committees such as social committee, publicity committee, and so on; however, such positions do not hold executive decision making authority.
+
+Termination of Executives or General Members:
+
+Any member of the club who commits an act negatively affecting the interests of the club and its members, including non-disclosure of a significant or continuing conflict of interest, may be given notice of removal. The member up for removal shall have the right to defend his/her actions. A vote will be held at an executive meeting, and a two-thirds majority vote of the current executives present in favor of removal is required.  The member must have the right to an appeal before the general membership, and the majority vote of the general membership will have the final say on the matter.
+
+The member will be removed from the club’s membership and will lose any privileges associated with being a member of the club.
+
+Executive members are subject to the same termination or impeachment process and, as determined by the vote, may lose their executive position along with their membership to the group.
+
+
+5.	Elections
+
+The executive committee shall strike the Elections Committee and appoint one (1) Chief Returning Officer (CRO) and two (2) Scrutinizers from the general members on the committee to conduct and hold elections in March. All members of the Elections Committee shall be non-biased in the results of the election and shall be required to disclose any and all conflicts of interest in the election.
+
+The CRO Returning Officer shall accept nominations only from group members that are also registered U of T members (staff, faculty, students and alumni) for candidacy of executive positions from the general membership before the beginning of March. Candidates have to be members in good standing and be part of the group for at least one month prior to the nomination period.
+
+The CRO shall select three (3) election dates before March 30th for the voting period. These dates will be announced in a minimum of two (2) weeks prior to elections dates and must fall on weekdays.
+
+The CRO and Scrutinizers shall provide each U of T member with a paper ballot on the voting dates and ask the member to place their ballot in an enclosed box. 
+
+In preparation for a tie, the CRO shall select an executive from amongst the executive committee, to cast their ballot and seal it in an envelope. In the event of a tie for an executive position, one of the two Scrutinizers shall break the seal and count the ballot in order to break the tie.
+
+After the election is over, the CRO and Scrutinizers shall count the ballots. The candidate with the most votes shall be elected to the position. The CRO and Scrutinizers shall submit a report of the results of the elections to the Executive Committee and general members. 
+
+Registered U of T members may not vote by proxy. Non-U of T members may not nominate or vote in elections. 
+
+Only U of T members who have paid any applicable membership fees and have been a member in good standing for 30 days prior to election dates are eligible for voting.
+
+Term of executive positions shall be from May 1st to April 30th.
+
+6.	Finances
+
+The Treasurer shall keep records of all income and expenses. The Treasurer shall present the group’s financial health at the annual general meetings. The Executive Committee will vote on expenditures of over $100.00 by majority vote at an executive meeting. 
+
+The group’s executive or members may not engage in activities that are essentially commercial in nature. This is not intended to preclude the collection of membership fees to cover the expenses of the group, or of charges for specific activities, programs or events, or to prohibit groups from engaging in legitimate fundraising. However, the group will not have as a major activity a function that makes it an on-campus part of a commercial organization, will not provide services and goods at a profit when that profit is used for purposes other than those of the organization, and will not pay salaries to some or all of its officers.
+
+7.	Meetings
+
+A) Annual General Meetings (AGMs):
+
+The group shall hold general meetings at least twice per year, i.e. once per academic term.
+
+The Executive Committee will announce these dates two (2) weeks prior to holding the meetings.  These meetings are intended to go over the group’s annual activity plan, financial health and propose or vote on constitutional amendments, if any. Motions will require 2/3 majority of registered members in attendance for a vote to be cast. The motion with the most votes will be passed. 
+
+b) Executive Meetings:
+
+The executive committee shall meet on a monthly basis where date and times are to be set by an executive.  The quorum of executive meetings shall be 50%+1 of executives.
+
+8.	Amendments
+
+Any registered U of T members may propose and vote on amendments to this constitution. The Executive Committee will administer the process of having amendments discussed at general meetings. 
+
+Constitutional amendments shall require a 2/3 majority to be passed at Annual General Meetings by registered U of T members in attendance. 
+
+The Executive Committee shall formally adopt the new constitution and submit the revised constitution to the respective University offices (i.e. The Office of Student Life, The University of Toronto Students’ Union, etc) within two (2) weeks of its approval by general members.
+


### PR DESCRIPTION
This is the template for our group's constitution, provided by ULife. It will be required when applying for ULife recognition, which will make all subsequent group affiliation requests way easier. We should aim to have this document up and ready to go by the second half of July, so fill in/ or comment on anything that you think should be added or changed!
