### PR TITLE
Changed updateCalendar.py with study group info

### DIFF
--- a/scripts/updateCalendar.py
+++ b/scripts/updateCalendar.py
@@ -41,12 +41,12 @@ except ImportError:
 
 # Modify these variables in step 2 above -------------------
 # APPLICATION_NAME: app name you created in step one above:
-APPLICATION_NAME = 'test'
+APPLICATION_NAME = 'UofTCoders Calendar'
 # CALENDAR_ID: google account name you created for your calendar:
-CALENDAR_ID = 'USER@gmail.com'
+CALENDAR_ID = 'utorontostudygroup@gmail.com'
 # TIME_ZONE_STR: check here:
 # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-TIME_ZONE_STR = 'America/Vancouver'
+TIME_ZONE_STR = 'America/Toronto'
 # -----------------------------------------------------------
 
 SCOPES = 'https://www.googleapis.com/auth/calendar'


### PR DESCRIPTION
I can now run updateCalendar.py locally and it automatically updates our Google Calendar based on the files in the _posts directory. I think it should be possible for anyone to run it and do the update, but I'm really not sure. 
