### PR TITLE
fix SWC R event by adding quotes around text description 

### DIFF
--- a/_posts/2016-04-25-SwcRUnixGit.markdown
+++ b/_posts/2016-04-25-SwcRUnixGit.markdown
@@ -1,6 +1,6 @@
 ---
 title: Software Carpentry Workshop (2 days) - R, Unix Shell and Git
-text: Join us for a hands-on two-day Software Carpentry workshop covering core small research team skills: programming with R, automating tasks with Unix Shell, and version control with Git. Workshop costs $20, click to see the event page for more details and registration!
+text: "Join us for a hands-on two-day Software Carpentry workshop covering core small research team skills: programming with R, automating tasks with Unix Shell, and version control with Git. Workshop costs $20, click to see the event page for more details and registration!"
 location: BL224, Claude T. Bissell Building, 140 St. George Street
 link: https://uoftcoders.github.io/2016-04-25-utoronto/
 date: 2016-04-25


### PR DESCRIPTION
Hey @lwjohnst86 thanks for merging, but it looks Iike I mucked up -- didn't throw quotes around the event description. Tested this with the quotes locally and the event shows correctly.
