### PR TITLE
Add SWC python event

### DIFF
--- a/_posts/2016-05-09-SwcPythonUnixGit.markdown
+++ b/_posts/2016-05-09-SwcPythonUnixGit.markdown
@@ -1,0 +1,9 @@
+---
+title: Software Carpentry Workshop (2 days) - Python, Unix Shell and Git
+text: "Join us for a hands-on two-day Software Carpentry workshop covering core small research team skills: building programs with Python, automating tasks with Unix Shell, and version control with Git. Workshop costs $20, click to see the event page for more details and registration!"
+location: BL224, Claude T. Bissell Building, 140 St. George Street
+link: https://uoftcoders.github.io/2016-05-09-utoronto/
+date: 2016-05-09
+startTime: '09:00'
+endTime: '16:00'
+---


### PR DESCRIPTION
Per the R event (#106 ), used the start date and time for the event and indicated it was two-day in the description and title text.

Tested locally and looks good.

No huge rush on this one, in fact, might be nice to leave the first event up by itself for a while, just wanted to get it ready while I had a moment!
