### PR TITLE
Add link to git branches video.

### DIFF
--- a/lessons/gitBranches/lesson.md
+++ b/lessons/gitBranches/lesson.md
@@ -10,6 +10,7 @@ visible: true
  - **Research field**: Nutritional and diabetes epidemiology
  - **Lesson topic**: Git branches
  - **Lesson content URL**: <https://github.com/UofTCoders/studyGroup/tree/gh-pages/lessons/gitBranches>
+ - **Lesson video stream**: <https://www.youtube.com/watch?v=nRUW6LLkCqQ>
 
 ## Preface: ##
 


### PR DESCRIPTION
I was just showing someone how this lesson was posted on YouTube, but it was _so_ hard to get to the link.
