### PR TITLE
Make lesson listing into two columns.

### DIFF
--- a/lessons/index.html
+++ b/lessons/index.html
@@ -1,13 +1,16 @@
 ---
 layout: page
 title: 'Lesson Material'
-visible: false
 ---
 
 <!-- Lesson section -->
 
+<div class="container">
+<div class="row">
+<div class="col-sm-6">
+<h2>By Topic</h2>
 {% for lang in site.languages %}
-<h2>{{ lang | capitalize }}</h2>
+<h3>{{ lang | capitalize }}</h3>
 
 <ul>
   {% assign pages_list = site.pages | sort: 'title' %}
@@ -22,11 +25,12 @@ visible: false
   {% endfor %}  <!-- node -->
 </ul>
 {% endfor %}  <!-- lang -->
+</div>
 
-<hr/>
-
+<div class="col-sm-6">
+<h2>By Level</h2>
 {% for level in site.levels %}
-<h2>{{ level | capitalize }}</h2>
+<h3>{{ level | capitalize }}</h3>
 
 <ul>
   {% assign pages_list = site.pages | sort: 'title' %}
@@ -41,3 +45,6 @@ visible: false
   {% endfor %}  <!-- node -->
 </ul>
 {% endfor %}  <!-- level -->
+</div>
+</div>
+</div>


### PR DESCRIPTION
I think it might be a bit annoying to scroll all the way through when you've got the horizontal real estate to make two columns. This second column gets triggered for screens >= 768px (the "small" size in Bootstrap) which I think looks good enough.

I'm not super happy about "By Learner Level"; suggestions welcome there. Also, should the columns be swapped?

![screen shot 2016-12-14 at 18 29 47](https://cloud.githubusercontent.com/assets/302469/21205650/677c730a-c22b-11e6-99c1-54e0405b1354.png)

