### PR TITLE
add freeCodeCamp and change ACM link

### DIFF
--- a/_includes/friends-and-resources.html
+++ b/_includes/friends-and-resources.html
@@ -17,7 +17,7 @@
           <div class='eventSub'>An interdisciplinary network of researchers at UofT studying how the rise of the Internet is changing society, politics and the economy — and vice versa.</div>
         </li>
 		<li>
-          <a class='eventTitle' href="http://ais.ischool.utoronto.ca/">The University of Toronto Association for Computer Machinery</a>
+          <a class='eventTitle' href="https://twitter.com/uoftacm">The University of Toronto Association for Computer Machinery</a>
           <div class='eventSub'>The University of Toronto Association for Computer Machinery Student Chapter, affiliated with the Faculty of Information iSchool. They also host professional and research skills workshops open to people from outside iSchool. </div>
         </li>
         <li>
@@ -37,7 +37,12 @@
 	 <a class='eventTitle'
 	    href="http://machinelearning.sitey.me/">University of Toronto Machine Learning Club</a>
 	 <div class='eventSub'>Join the Machine Learning Club to work through machine learning tutorials. No pre-requisite knowledge of machine learning is required. The club will aim to encourage students to pursue and also share their interests in the field of data science and machine learning. </div>
-      </li>
+      	</li>
+        <li>
+          <a class='eventTitle'
+             href="https://www.facebook.com/groups/free.code.camp.to/">freeCodeCamp Toronto</a>
+          <div class='eventSub'>Weekly meetups for community members to work on coding projects together plus technical workshops and guest speakers.</div>
+        </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Add freeCodeCamp to friends and resources and change the ischool ACM link - it appears to be defunct. 