### PR TITLE
Minor edits and add section on live-coding with examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 layout: page
 title: Contributing to UofT Coders
 ---
-Welcome to the Contributing guideline for UofT Coders. Thanks for taking the time to contribute! :clap::clap:  
+Welcome to the Contributing guideline for UofT Coders. Thanks for taking the time to contribute! 
 
 The following is a set of guidelines for contributing to the UofT Coders community, whether it be by teaching a lesson, fixing the website, helping to plan and organize our various events, or taking on a leadership role.
 
@@ -21,25 +21,26 @@ The following is a set of guidelines for contributing to the UofT Coders communi
 -----
 # About UofT Coders
 
-The UofT Coders group was formed to share and learn about coding techniques and
+UofT Coders was formed to share and learn about coding techniques and
 best practices for computing and analysis in research. We hold weekly sessions
 in the format of code-alongs, coworking sessions or journal clubs/discussions.
-To see our previous and upcoming events, you can visit our [Events repo](https://github.com/UofTCoders/Events/issues).
+To see our previous and upcoming events, you can visit our [Events repo](https://github.com/UofTCoders/Events/issues) or [website](https://uoftcoders.github.io/studyGroup/#events).
 To learn more about our group, you can read our [constitution](https://github.com/UofTCoders/council/blob/master/Constitution.md).
 
 ## Code of Conduct
 
 We adhere to a [Code of Conduct](https://github.com/UofTCoders/studyGroup/blob/gh-pages/codeOfConduct.md)
-and by participating, you agree to also uphold this code. Please report any
-unacceptable behaviour to uoftcoders@gmail.com. If you feel that the exec has
-been violating the Code of Conduct, please email groups.officer@utoronto.ca to report.
+and by participating, you agree to also uphold this code. Please report any 
+unacceptable behaviour to uoftcoders@gmail.com. If you feel that a member of 
+the executive team has been violating the Code of Conduct, please email 
+groups.officer@utoronto.ca to report.
 
 -----
 # How You Can Contribute
 
 ## Leading a Lesson
 
-The Mozilla Science Study Group
+The Mozilla Study Group
 handbook [**here**](https://mozillascience.github.io/studyGroupHandbook/lessons.html#reuse)
 and [**here**](https://mozillascience.github.io/studyGroupHandbook/event-types.html#workalong)
 has several very good points about making a lesson. This section summarizes bits
@@ -48,18 +49,40 @@ of the handbook, but also adds pieces that are missing from it. Check out the
 
 ### Creating the Content
 
-+ **Use Built-in Datasets**: Use built-in sample datasets instead of requiring
-attendees to download files.
++ **Minimal use of slides**: The most effective sessions are ones that are very
+hands-on. We strongly encourage [*live-coding*](#more-on-live-coding) as a 
+teaching method; it's best to keep slides to a minimum or avoid them completely.
 + **Keep in mind beginners**: Make few assumptions about the knowledge of the audience,
 unless specified that this is an intermediate level lesson, requiring prior knowledge.
-Keep it simple.
-+ **Minimal use of slides**: If your lesson involves coding, keep slides to a minimum
-if at all, focus on interactive live-coding.
+Keep it simple. Don't attempt to cover too much material in a single session.
++ **Use Built-in Datasets**: Use built-in sample datasets instead of requiring
+attendees to download files. 
 + **Code Review**: The lesson code is posted to GitHub along with a pull request to
 [UofTCoders/studyGroup](https://github.com/UofTCoders/studyGroup) repository at
 least 1 full day prior to the lesson date to allow for review.
 See [Submitting a Pull Request](https://uoftcoders.github.io/studyGroup/pull-request/)
 
+#### More on Live-Coding
+
+Live-coding is a hands-on method of teaching coding to a group in which the instructor 
+shares their screen with the group and types all commands on their computer while the 
+group follows along. Live-coding is a very effective teaching technique: it forces the 
+instructor to go slowly and ensures that participants get to try out every command 
+being used. It allows learners to experience common errors themselves and debug them 
+in a supportive environment, to explore variations on material as they go, and to 
+immediately check their understanding by trying things hands-on. 
+
+Live-coding is a technique used by [Software Carpentry](https://software-carpentry.org/about/). 
+Software Carpentry has lots of great resources explaining the why and how of live-coding:
++ [10 tips and tricks for instructing and teaching by means of live coding](https://software-carpentry.org/blog/2016/04/tips-tricks-live-coding.html)
++ The Software Carpentry [instructor training manual](http://carpentries.github.io/instructor-training/) 
+includes many resources about programming education.
+
+To see live-coding in action in the UofT Coders group, watch a portion of the 
+[Intro to R livestream](https://www.youtube.com/watch?v=b74V54VFL98) taught by 
+[Ahmmed](https://github.com/aays), or look over the code that was covered in an 
+[R lesson](https://github.com/UofTCoders/studyGroup/blob/gh-pages/lessons/r/intro/Intro_R_Sept21.R) 
+created by [Luke](https://github.com/lwjohnst86). 
 
 ### Teaching in Class
 
@@ -74,6 +97,10 @@ See [Submitting a Pull Request](https://uoftcoders.github.io/studyGroup/pull-req
 
 + **Live-coding**: Use of slides is minimal, majority of lesson involves writing the code WITH the audience during the lesson
 + **Stay on topic**: There is only one hour, if a question arises that is off-topic, you can always suggest discussing afterwards.
++ **Check in with participants**: We distribute coloured sticky notes to each 
+participant so that they can flag problems with one colour and success with 
+another colour. Use these indicators to stay aware of your pacing and where the group is at, 
+and/or verbally ask how everyone is doing and leave time for questions.
 
 -----
 


### PR DESCRIPTION
As discussed at our last meeting, I added a section that talks more about live-coding and made the language stronger around *you must live-code*. 

I made a few small edits in other places as well and took out the claps because they don't render on the website. 

I also added a note about sticky notes in the in-class section.