### PR TITLE
Add modified intro python lesson

### DIFF
--- a/lessons/python/intro/IntroPython-AH.ipynb
+++ b/lessons/python/intro/IntroPython-AH.ipynb
@@ -354,7 +354,7 @@
    "outputs": [],
    "source": [
     "x = 5\n",
-    "type(x) == int"
+    "isinstance(x, int)"
    ]
   },
   {
@@ -367,7 +367,7 @@
     "# if statements allow our scripts to encode more complex instructions\n",
     "\n",
     "x = 5\n",
-    "if type(x) == int:\n",
+    "if isinstance(x, int):\n",
     "    print(x, 'is an integer')\n"
    ]
   },
@@ -379,7 +379,7 @@
    "source": [
     "# if-else\n",
     "\n",
-    "if type(x) == str:\n",
+    "if isinstance(x, str):\n",
     "    print(x, 'is a string')\n",
     "else:\n",
     "    print(x, 'is not a string')"
@@ -394,9 +394,9 @@
     "# if-elif-else\n",
     "# useful if we have multiple conditions to test\n",
     "\n",
-    "if type(x) == str:\n",
+    "if isinstance(x, str):\n",
     "    print(x, 'is a string')\n",
-    "elif type(x) == int:\n",
+    "elif isinstance(x, int):\n",
     "    print(x, 'is an integer')\n",
     "else:\n",
     "    print(x, 'is neither a string nor an integer')"
@@ -651,7 +651,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.relplot(x = 'petal_length', y = 'petal_width', data = iris)"
+    "sns.relplot(x='petal_length', y='petal_width', data=iris)"
    ]
   },
   {
@@ -660,7 +660,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.relplot(x = 'petal_length', y = 'petal_width', hue = 'species', data = iris)"
+    "sns.relplot(x='petal_length', y='petal_width', hue='species', data=iris)"
    ]
   }
  ],

--- a/lessons/python/intro/IntroPython-AH.ipynb
+++ b/lessons/python/intro/IntroPython-AH.ipynb
@@ -1,0 +1,688 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Intro to Python\n",
+    "\n",
+    "## UofT Coders, Jan 10 2019\n",
+    "\n",
+    "**Author**: Ahmed Hasan, borrowing heavily from Madeleine Bonsma-Fisher, Lina Tran, Charles Zhu, and Amanda Easson\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## The interpreter\n",
+    "\n",
+    "### Math with _integers_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "2 + 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "2 * 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "2 ** 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# % is the modulus operator\n",
+    "# x % y -> return the remainder of x / y\n",
+    "2 % 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Math with _floats_\n",
+    "\n",
+    "Floats = floating point numbers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "2.0 * 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "2.5 * 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "2 * 3;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "year = 2019\n",
+    "name = 'Ahmed' # this is a string"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(year)\n",
+    "\n",
+    "print(name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(type(name))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(type(2.0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(type(year))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# how exactly does print work again?\n",
+    "\n",
+    "help(print)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Lists"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# lists - square brackets!\n",
+    "\n",
+    "fruits = ['apple', 'orange', 'mango']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(fruits)\n",
+    "print(type(fruits))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "misc = [42, 'python!', 2.57]\n",
+    "print(misc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# concatenating lists\n",
+    "fruits + fruits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Indexing lists and strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# indexing in python begins at 0! \n",
+    "\n",
+    "print(fruits[0])\n",
+    "print(type(fruits[0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# slicing multiple things\n",
+    "# start : end (exclusive!)\n",
+    "\n",
+    "# recall that fruits = ['apple', 'orange', 'mango']\n",
+    "\n",
+    "print(fruits[0:2])\n",
+    "print(fruits[0:])\n",
+    "print(fruits[:3])\n",
+    "\n",
+    "print(fruits[-1]) # last item of a list\n",
+    "print(fruits[-2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# reassigning item in list\n",
+    "fruits[2] = 'banana'\n",
+    "print(fruits)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# slicing and indexing strings\n",
+    "\n",
+    "my_string = 'This is a string.'\n",
+    "\n",
+    "print(my_string[1:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# strings do not support reassignment\n",
+    "# try running this: my_string[0] = 't'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dictionaries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# dictionaries allow us to store key value pairs\n",
+    "\n",
+    "fruit_colors = {'banana': 'yellow',\n",
+    "                'apple': 'red',\n",
+    "                'orange': 'orange'}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# keys are 'looked up' using square brackets\n",
+    "\n",
+    "print(fruit_colors['banana'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# additional keys can be added after the fact\n",
+    "fruit_colors['lemon'] = 'yellow'\n",
+    "print(fruit_colors)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## If statements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# python can check whether certain statements are true or false\n",
+    "\n",
+    "2 > 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# use == to test for equality\n",
+    "1 == 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = 5\n",
+    "type(x) == int"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# with these expressions, we can construct if statements\n",
+    "# if statements allow our scripts to encode more complex instructions\n",
+    "\n",
+    "x = 5\n",
+    "if type(x) == int:\n",
+    "    print(x, 'is an integer')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if-else\n",
+    "\n",
+    "if type(x) == str:\n",
+    "    print(x, 'is a string')\n",
+    "else:\n",
+    "    print(x, 'is not a string')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if-elif-else\n",
+    "# useful if we have multiple conditions to test\n",
+    "\n",
+    "if type(x) == str:\n",
+    "    print(x, 'is a string')\n",
+    "elif type(x) == int:\n",
+    "    print(x, 'is an integer')\n",
+    "else:\n",
+    "    print(x, 'is neither a string nor an integer')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## For loops"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# for loops allow us to automate repetitive operations\n",
+    "\n",
+    "# how do we check which values in this list are even?\n",
+    "nums = [1, 2, 3, 4]\n",
+    "\n",
+    "# could check them individually?\n",
+    "print(nums[0] % 2)\n",
+    "print(nums[1] % 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# for loops simplify this\n",
+    "# here, 'number' is a placeholder variable for each of the items in the list\n",
+    "\n",
+    "for number in nums:\n",
+    "    if number % 2 == 0:\n",
+    "        print(number, 'is even')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# we can also loop over the contents of a string\n",
+    "vowels = 'aeiou'\n",
+    "for letter in vowels:\n",
+    "    print(letter)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# functions allow us to generalize operations\n",
+    "# what is the sum of squares of two numbers?\n",
+    "\n",
+    "x = 5\n",
+    "y = 7\n",
+    "\n",
+    "print((x ** 2) + (y ** 2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sum_of_squares(num1, num2):\n",
+    "    ''' (int, int) -> int\n",
+    "    input: two integers\n",
+    "    output: the sum of the squares of the two numbers\n",
+    "    '''\n",
+    "    ss_out = num1 ** 2 + num2 ** 2\n",
+    "    return ss_out\n",
+    "\n",
+    "# def is the keyword to define functions\n",
+    "# each function typically ends with a return statement"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output = sum_of_squares(x, y)\n",
+    "print(output) # our operation from above\n",
+    "print(sum_of_squares(50, 42)) # works with any values we want!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# checking on our docstring\n",
+    "help(sum_of_squares)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Some useful packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# use a package by importing it\n",
+    "# these can be given a shorter alias\n",
+    "\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# packages provide all sorts of useful functionality\n",
+    "# numpy allows for efficient numerical calculations in python\n",
+    "\n",
+    "np_array = np.arange(15)\n",
+    "list_array = list(range(15))\n",
+    "\n",
+    "print(np_array)\n",
+    "print(type(np_array))\n",
+    "print(list_array)\n",
+    "print(type(list_array))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# numpy arrays also allow for vectorized operations\n",
+    "\n",
+    "print(np_array * 2)\n",
+    "print(list_array * 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# numpy arrays also have helpful 'methods'\n",
+    "# a method is a special function 'attached' to an object, to be used on the object itself\n",
+    "\n",
+    "# what's the mean of our array?\n",
+    "print(np_array.mean())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# the max value in our array?\n",
+    "print(np_array.max())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import seaborn as sns # we will use this for plotting\n",
+    "%matplotlib inline\n",
+    "iris = sns.load_dataset('iris')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iris.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iris.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pull out specific rows with the .loc method\n",
+    "iris.loc[0:2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# or rows AND columns\n",
+    "# use a list for multiple columns!\n",
+    "\n",
+    "iris.loc[0:2, 'petal_length']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iris.loc[0:2, ['petal_length', 'species']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.relplot(x = 'petal_length', y = 'petal_width', data = iris)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.relplot(x = 'petal_length', y = 'petal_width', hue = 'species', data = iris)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda root]",
+   "language": "python",
+   "name": "conda-root-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This version of the lesson is largely based on [Madeleine's](https://github.com/UofTCoders/studyGroup/blob/gh-pages/lessons/python/intro/IntroPython-MB.ipynb), save for a few minor differences in the first half. 

At the end, I've added some brief `seaborn`, and also use `sns.load_dataset` to load in a built-in dataset instead of having participants download a file. 