### PR TITLE
Fix bugged event links

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -13,7 +13,7 @@
   # Where the event will take place
   location: UofT Coders Discord server
   # The URL for the location
-  location_url: ""
+  location_url: "https://github.com/UofTCoders/Events/issues/304"
   # Packages to install, a space separating each package
   # (e.g. "dplyr tidyr" or "Pandas>=0.21 Seaborn")
   packages: ""
@@ -40,7 +40,7 @@
   # Where the event will take place
   location: UofT Coders Discord server
   # The URL for the location
-  location_url: ""
+  location_url: "https://github.com/UofTCoders/Events/issues/305"
   # Packages to install, a space separating each package
   # (e.g. "dplyr tidyr" or "Pandas>=0.21 Seaborn")
   packages: ""
@@ -67,7 +67,7 @@
   # Where the event will take place
   location: UofT Coders Discord server
   # The URL for the location
-  location_url: ""
+  location_url: "https://github.com/UofTCoders/Events/issues/306"
   # Packages to install, a space separating each package
   # (e.g. "dplyr tidyr" or "Pandas>=0.21 Seaborn")
   packages: ""
@@ -93,7 +93,7 @@
   # Where the event will take place
   location: UofT Coders Discord server
   # The URL for the location
-  location_url: ""
+  location_url: "https://github.com/UofTCoders/Events/issues/307"
   # Packages to install, a space separating each package
   # (e.g. "dplyr tidyr" or "Pandas>=0.21 Seaborn")
   packages: "ggplot2 dplyr"
@@ -107,7 +107,7 @@
 
 - key: python-scikit-learn
   # Title of event that will show up as the GH Issue title
-  title: "Python: scikit-learn"
+  title: "Python: Machine learning with scikit-learn"
   # Explanation of event as a paragraph form
   description: >
     An introduction to using scikit-learn in Python.
@@ -119,7 +119,7 @@
   # Where the event will take place
   location: UofT Coders Discord server
   # The URL for the location
-  location_url: ""
+  location_url: "https://github.com/UofTCoders/Events/issues/308"
   # Packages to install, a space separating each package
   # (e.g. "dplyr tidyr" or "Pandas>=0.21 Seaborn")
   packages: "scikit-learn"
@@ -146,7 +146,7 @@
   # Where the event will take place
   location: UofT Coders Discord server
   # The URL for the location
-  location_url: ""
+  location_url: "https://github.com/UofTCoders/Events/issues/309"
   # Packages to install, a space separating each package
   # (e.g. "dplyr tidyr" or "Pandas>=0.21 Seaborn")
   packages: "pandoc"
@@ -172,7 +172,7 @@
   # Where the event will take place
   location: UofT Coders Discord server
   # The URL for the location
-  location_url: ""
+  location_url: "https://github.com/UofTCoders/Events/issues/310"
   # Packages to install, a space separating each package
   # (e.g. "dplyr tidyr" or "Pandas>=0.21 Seaborn")
   packages: ""
@@ -198,7 +198,7 @@
   # Where the event will take place
   location: UofT Coders Discord server
   # The URL for the location
-  location_url: ""
+  location_url: "https://github.com/UofTCoders/Events/issues/311"
   # Packages to install, a space separating each package
   # (e.g. "dplyr tidyr" or "Pandas>=0.21 Seaborn")
   packages: ""

--- a/_posts/2021-10-06-intro-python.md
+++ b/_posts/2021-10-06-intro-python.md
@@ -3,7 +3,7 @@ title: "Introduction to Python"
 text: "A brief introduction to Python for beginners.
 "
 location: "UofT Coders Discord server"
-link: "NA"
+link: "https://github.com/UofTCoders/Events/issues/304"
 date: "2021-10-06"
 startTime: "18:00"
 endTime: "19:00"

--- a/_posts/2021-11-03-python-scikit-learn.md
+++ b/_posts/2021-11-03-python-scikit-learn.md
@@ -1,9 +1,9 @@
 ---
-title: "Python: scikit-learn"
+title: "Python: Machine learning with scikit-learn"
 text: "An introduction to using scikit-learn in Python.
 "
 location: "UofT Coders Discord server"
-link: "NA"
+link: "https://github.com/UofTCoders/Events/issues/308"
 date: "2021-11-03"
 startTime: "18:00"
 endTime: "19:00"

--- a/_posts/2021-11-17-lightning-demos.md
+++ b/_posts/2021-11-17-lightning-demos.md
@@ -3,7 +3,7 @@ title: "Lightning demos"
 text: "Short coding demos - anyone is welcome to present!
 "
 location: "UofT Coders Discord server"
-link: "NA"
+link: "https://github.com/UofTCoders/Events/issues/310"
 date: "2021-11-17"
 startTime: "18:00"
 endTime: "19:00"

--- a/_posts/2021-12-01-r-blogdown.md
+++ b/_posts/2021-12-01-r-blogdown.md
@@ -3,7 +3,7 @@ title: "Creating websites with RStudio and blogdown"
 text: "An overview of how to create personal and professional websites using blogdown in RStudio.
 "
 location: "UofT Coders Discord server"
-link: "NA"
+link: "https://github.com/UofTCoders/Events/issues/311"
 date: "2021-12-01"
 startTime: "18:00"
 endTime: "19:00"


### PR DESCRIPTION
My mistake - the issue names and event names in `events.yml` weren't exactly the same! This should fix it, although I'm can't remember whether `location_url` was the original means of linking the issues. Seems to work here though? 